### PR TITLE
added new groups of VMs 'additional-helper' and 'nuage' as RHEL7 VMs

### DIFF
--- a/ansible/config/storm3.coe.muc.redhat.com.yml
+++ b/ansible/config/storm3.coe.muc.redhat.com.yml
@@ -279,6 +279,19 @@ external_network_config:
           - from_port: 22
             to_port: 22
             proto: tcp
+      - expose_machine: rh-sso
+        on_host_prefix: 10.32.105.179/32
+        via_network: services
+        ports:
+          - from_port: 80
+            to_port: 80
+            proto: tcp
+          - from_port: 443
+            to_port: 443
+            proto: tcp
+          - from_port: 22
+            to_port: 22
+            proto: tcp
   guest_network_bridging:
     layer1_dev: em2
     default_gw_host_prefix: 10.32.111.254/20

--- a/ansible/create-01-base.yml
+++ b/ansible/create-01-base.yml
@@ -161,3 +161,47 @@
 #     - { role: layer2_rhel, tags: [ 'layer2', 'storage-console', 'rhel' ], mode: create }
 #     - { role: layer2_ipa_certificate, tags: ['layer2', 'storage-console', 'cert' ], mode: create }
 #     - { role: layer2_storageconsole, tags: [ 'layer2', 'storage-console', 'storage-console-install' ], mode: create }
+
+# create the "additional-helper" VMs, subscribe against satellite,
+# install packages defined in groups/newgroup.yml and
+# register IPA client
+# ansible-playbook -i hosts -e @config/infrastructure_config.yml -e @config/hailstorm_config.yml -e @config/storm3.coe.muc.redhat.com.yml create-01-base.yml --tags additional-helper
+- hosts: additional-helper
+  remote_user: root
+  gather_facts: false
+  roles:
+    - role: layer2_vms
+      tags: [ 'layer2', 'additional-helper', 'vm' ]
+      mode: create
+    - role: layer2_rhel_reconfigure_dns
+      tags: [ 'layer2', 'additional-helper', 'dns' ]
+      mode: create
+      nameserver: "{{ hostvars['ipa'].vm_nics[0].ip }}"
+    - role: layer2_rhel
+      tags: [ 'layer2', 'additional-helper', 'rhel' ]
+      mode: create
+    - role: layerX_ipa_client
+      tags: [ 'layer2', 'additional-helper',  'ipa-client']
+      mode: create
+
+# create the "nuage" VMs, subscribe against satellite,
+# install packages defined in groups/newgroup.yml and
+# register IPA client
+# ansible-playbook -i hosts -e @config/infrastructure_config.yml -e @config/hailstorm_config.yml -e @config/storm3.coe.muc.redhat.com.yml create-01-base.yml --tags nuage
+- hosts: nuage
+  remote_user: root
+  gather_facts: false
+  roles:
+    - role: layer2_vms
+      tags: [ 'layer2', 'nuage', 'vm' ]
+      mode: create
+    - role: layer2_rhel_reconfigure_dns
+      tags: [ 'layer2', 'nuage', 'dns' ]
+      mode: create
+      nameserver: "{{ hostvars['ipa'].vm_nics[0].ip }}"
+    - role: layer2_rhel
+      tags: [ 'layer2', 'nuage', 'rhel' ]
+      mode: create
+    - role: layerX_ipa_client
+      tags: [ 'layer2', 'nuage',  'ipa-client']
+      mode: create

--- a/ansible/destroy.yml
+++ b/ansible/destroy.yml
@@ -1,4 +1,42 @@
 ---
+- hosts: additional-helper
+  gather_facts: false
+  remote_user: root
+  roles:
+    - role: layer2_vms
+      tags: [ 'layer2','additional-helper', 'vm' ]
+      mode: start
+    - role: layerX_ipa_client
+      tags: [ 'layer2','additional-helper', 'ipa-client' ]
+      mode: destroy
+      when: vm_exists is defined and vm_exists == true
+    - role: layer2_rhel
+      tags: [ 'layer2','additional-helper', 'rhel' ]
+      mode: destroy
+      when: vm_exists is defined and vm_exists == true
+    - role: layer2_vms
+      tags: [ 'layer2','additional-helper', 'vm' ]
+      mode: destroy
+
+- hosts: nuage
+  gather_facts: false
+  remote_user: root
+  roles:
+    - role: layer2_vms
+      tags: [ 'layer2','nuage', 'vm' ]
+      mode: start
+    - role: layerX_ipa_client
+      tags: [ 'layer2','nuage', 'ipa-client' ]
+      mode: destroy
+      when: vm_exists is defined and vm_exists == true
+    - role: layer2_rhel
+      tags: [ 'layer2','nuage', 'rhel' ]
+      mode: destroy
+      when: vm_exists is defined and vm_exists == true
+    - role: layer2_vms
+      tags: [ 'layer2','nuage', 'vm' ]
+      mode: destroy
+
 # - hosts: test-rhel
 #   gather_facts: false
 #   remote_user: root

--- a/ansible/group_vars/additional-helper.yml
+++ b/ansible/group_vars/additional-helper.yml
@@ -1,0 +1,32 @@
+mem: 4096
+vcpu: 2
+
+disk:
+  path: "{{ inventory_hostname_short }}.qcow2"
+  size: 100
+  format: qcow2
+  # partition_table:
+  #   lvmpv: 29500
+  #   swap: 2048
+  #   home: 2048
+  #   root: 10000
+
+  physvols:
+    boot: 500
+    rhel: 99500
+  logvols:
+    - name: swap
+      fstype: swap
+      mountpoint: swap
+      size: 2048
+    - name: root
+      fstype: "{{ fstype }}"
+      mountpoint: /
+      size: 10000
+    - name: home
+      fstype: "{{ fstype }}"
+      mountpoint: /home
+      size: 2048
+
+packages: git,python
+pool_regex: "{{ rhel_subscription_pool_regex }}"

--- a/ansible/group_vars/nuage.yml
+++ b/ansible/group_vars/nuage.yml
@@ -1,0 +1,32 @@
+mem: 4096
+vcpu: 2
+
+disk:
+  path: "{{ inventory_hostname_short }}.qcow2"
+  size: 100
+  format: qcow2
+  # partition_table:
+  #   lvmpv: 29500
+  #   swap: 2048
+  #   home: 2048
+  #   root: 10000
+
+  physvols:
+    boot: 500
+    rhel: 99500
+  logvols:
+    - name: swap
+      fstype: swap
+      mountpoint: swap
+      size: 2048
+    - name: root
+      fstype: "{{ fstype }}"
+      mountpoint: /
+      size: 10000
+    - name: home
+      fstype: "{{ fstype }}"
+      mountpoint: /home
+      size: 2048
+
+packages: git,python
+pool_regex: "{{ rhel_subscription_pool_regex }}"

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -89,6 +89,14 @@ lookbusy-rhev   ansible_host=192.168.103.39 activation_key="AK-CV-OS-RHEL7-SERVE
 [storage-console]
 storage-console ansible_host=192.168.103.9 activation_key="AK-CV-CEPH-{{ stage }}"
 
+[additional-helper]
+install-host ansible_host=192.168.103.6 activation_key="AK-CV-OS-RHEL7-SERVER-{{ stage }}"
+rh-sso ansible_host=192.168.103.7 activation_key="AK-CV-OS-RHEL7-SERVER-{{ stage }}"
+
+[nuage]
+vsd ansible_host=192.168.103.8 activation_key="AK-CV-OS-RHEL7-SERVER-{{ stage }}"
+vsc ansible_host=192.168.103.9 activation_key="AK-CV-OS-RHEL7-SERVER-{{ stage }}"
+
 # virtual IPs - these will not be instantiated through Ansible (but need them for DNS records, DNAT, etc)
 [vips]
 openstack       ansible_host=192.168.101.81 nic_attachments="[ {{ infrastructure_network_services }} ]" default_route_via="{{ infrastructure_network_services }}"
@@ -160,6 +168,8 @@ ose3-master1
 
 # All layer2 node groups that are installed with RHEL7
 [rhel7:children]
+additional-helper
+nuage
 rhosp-all
 satellite
 rhevh
@@ -182,6 +192,8 @@ test-rhel6
 
 # everything on layer2
 [layer2:children]
+additional-helper
+nuage
 ose3
 satellite
 rhev
@@ -206,6 +218,8 @@ lookbusy-rhev
 
 # A group to capture all nodes with standard 3-NIC network layout (services, admin, storage)
 [niclayout-standard:children]
+additional-helper
+nuage
 satellite
 test-rhel
 infrastructure


### PR DESCRIPTION
Here are the additional VMs needed. VM rh-sso is already rolled out on storm3. Command used was:
ansible-playbook -i hosts -e @config/infrastructure_config.yml -e @config/hailstorm_config.yml -e @config/storm3.coe.muc.redhat.com.yml create-01-base.yml --tags additional-helper --skip-tags satellite